### PR TITLE
chore(compose): parameterize socket path for Podman compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
 # Beszel agent SSH public key (from Beszel hub UI > Add System)
 BESZEL_AGENT_KEY=ssh-ed25519 AAAA...your-key-here
+
+# Docker socket path for socket-proxy and beszel-agent
+# Docker (default — leave unset or use the value below)
+# DOCKER_SOCKET=/var/run/docker.sock
+
+# Podman (macmini-devserver — rootless)
+# DOCKER_SOCKET=/run/user/501/podman/podman.sock

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,35 @@
+name: Codex
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+jobs:
+  codex:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Codex
+        uses: openai/codex-action@v1
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -92,9 +92,34 @@ qwickguard/
 
 ### Deploy monitoring stack
 
+**Docker:**
 ```bash
 ssh macmini-devserver 'cd ~/Projects/qwickguard && git pull && docker compose up -d'
 ```
+
+**Podman (macmini-devserver):**
+
+First, ensure the Podman socket is active (one-time setup):
+```bash
+# Linux (systemd)
+systemctl --user enable --now podman.socket
+
+# macOS (Homebrew)
+launchctl load ~/Library/LaunchAgents/homebrew.mxcl.podman.plist
+```
+
+Then deploy:
+```bash
+ssh macmini-devserver 'cd ~/Projects/qwickguard && git pull && DOCKER_SOCKET=/run/user/501/podman/podman.sock podman compose up -d'
+```
+
+Alternatively, create a symlink so the default socket path works:
+```bash
+sudo ln -s /run/user/501/podman/podman.sock /var/run/docker.sock
+# then: docker compose up -d (or podman compose up -d)
+```
+
+Set `DOCKER_SOCKET` in `.env` to avoid passing it on every command (see `.env.example`).
 
 ### Install/update agent on macmini
 

--- a/brain/src/qwickguard_brain/api/dashboard.py
+++ b/brain/src/qwickguard_brain/api/dashboard.py
@@ -225,15 +225,28 @@ def _render_markdown(text: str) -> str:
 # Common context builder
 # ---------------------------------------------------------------------------
 
-async def _get_agent() -> dict[str, Any] | None:
-    """Get the first (primary) agent."""
+async def _get_agent(agent_id: str | None = None) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Get the selected agent and the full agents list.
+
+    If *agent_id* is provided, look it up.  Otherwise fall back to the first
+    registered agent (backward-compatible default).
+
+    Returns ``(selected_agent, all_agents)``.
+    """
     agents = await get_agents()
-    return agents[0] if agents else None
+    if not agents:
+        return None, []
+    if agent_id:
+        for a in agents:
+            if a["agent_id"] == agent_id:
+                return a, agents
+    return agents[0], agents
 
 
 async def _build_template_context(request: Request) -> dict[str, Any]:
     """Fetch agent data and assemble the Jinja2 template context dict."""
-    agent = await _get_agent()
+    agent_id = request.query_params.get("agent_id")
+    agent, agents = await _get_agent(agent_id)
 
     report: dict[str, Any] = {}
     actions: list[dict[str, Any]] = []
@@ -246,6 +259,8 @@ async def _build_template_context(request: Request) -> dict[str, Any]:
     return {
         "request": request,
         "agent": agent,
+        "agents": agents,
+        "selected_agent_id": agent["agent_id"] if agent else "",
         "report": report,
         "actions": actions,
         "relative_time": _relative_time,
@@ -276,13 +291,15 @@ async def overview_partial(request: Request) -> HTMLResponse:
 # ---------------------------------------------------------------------------
 
 @router.get("/metrics", response_class=HTMLResponse)
-async def metrics_page(request: Request, range: str = "24h") -> HTMLResponse:
+async def metrics_page(request: Request, range: str = "24h", agent_id: str | None = None) -> HTMLResponse:
     """Render the metrics charts page with historical data."""
-    agent = await _get_agent()
+    agent, agents = await _get_agent(agent_id)
     if not agent:
         return templates.TemplateResponse("metrics.html", {
             "request": request,
             "agent": None,
+            "agents": [],
+            "selected_agent_id": "",
             "chart_data": {"timestamps": []},
             "range": range,
         })
@@ -294,15 +311,17 @@ async def metrics_page(request: Request, range: str = "24h") -> HTMLResponse:
     return templates.TemplateResponse("metrics.html", {
         "request": request,
         "agent": agent,
+        "agents": agents,
+        "selected_agent_id": agent["agent_id"],
         "chart_data": chart_data,
         "range": range,
     })
 
 
 @router.get("/metrics/partials/charts", response_class=HTMLResponse)
-async def metrics_charts_partial(request: Request, range: str = "24h") -> HTMLResponse:
+async def metrics_charts_partial(request: Request, range: str = "24h", agent_id: str | None = None) -> HTMLResponse:
     """Return the inner metrics charts content fragment for HTMX auto-refresh."""
-    agent = await _get_agent()
+    agent, _agents = await _get_agent(agent_id)
     if not agent:
         return templates.TemplateResponse("partials/metrics_charts.html", {
             "request": request,
@@ -324,9 +343,9 @@ async def metrics_charts_partial(request: Request, range: str = "24h") -> HTMLRe
 
 
 @router.get("/api/metrics/data", response_class=JSONResponse)
-async def metrics_data_json(range: str = "24h") -> JSONResponse:
+async def metrics_data_json(range: str = "24h", agent_id: str | None = None) -> JSONResponse:
     """Return chart data as JSON for in-place chart updates (no page reload)."""
-    agent = await _get_agent()
+    agent, _agents = await _get_agent(agent_id)
     if not agent:
         return JSONResponse({"timestamps": []})
 
@@ -346,9 +365,10 @@ async def audit_page(
     action: str | None = None,
     result: str | None = None,
     page: int = 1,
+    agent_id: str | None = None,
 ) -> HTMLResponse:
     """Render the audit log page with filterable action history."""
-    agent = await _get_agent()
+    agent, agents = await _get_agent(agent_id)
     all_actions: list[dict[str, Any]] = []
 
     if agent:
@@ -374,6 +394,8 @@ async def audit_page(
     return templates.TemplateResponse("audit.html", {
         "request": request,
         "agent": agent,
+        "agents": agents,
+        "selected_agent_id": agent["agent_id"] if agent else "",
         "actions": page_actions,
         "available_actions": available_actions,
         "filters": {"action": action or "", "result": result or ""},
@@ -388,21 +410,23 @@ async def audit_page(
 # ---------------------------------------------------------------------------
 
 @router.get("/runbooks", response_class=HTMLResponse)
-async def runbooks_list(request: Request) -> HTMLResponse:
+async def runbooks_list(request: Request, agent_id: str | None = None) -> HTMLResponse:
     """List all available runbooks."""
-    agent = await _get_agent()
+    agent, agents = await _get_agent(agent_id)
     runbooks = _scan_runbooks(_RUNBOOKS_DIR)
     return templates.TemplateResponse("runbooks.html", {
         "request": request,
         "agent": agent,
+        "agents": agents,
+        "selected_agent_id": agent["agent_id"] if agent else "",
         "runbooks": runbooks,
     })
 
 
 @router.get("/runbooks/{filename}", response_class=HTMLResponse)
-async def runbook_detail(request: Request, filename: str) -> HTMLResponse:
+async def runbook_detail(request: Request, filename: str, agent_id: str | None = None) -> HTMLResponse:
     """Render a single runbook as HTML."""
-    agent = await _get_agent()
+    agent, agents = await _get_agent(agent_id)
 
     # Sanitize filename to prevent directory traversal
     safe_name = Path(filename).name
@@ -421,6 +445,8 @@ async def runbook_detail(request: Request, filename: str) -> HTMLResponse:
     return templates.TemplateResponse("runbook_detail.html", {
         "request": request,
         "agent": agent,
+        "agents": agents,
+        "selected_agent_id": agent["agent_id"] if agent else "",
         "content": html_content,
         "title": title,
         "filename": safe_name,
@@ -435,11 +461,13 @@ async def runbook_detail(request: Request, filename: str) -> HTMLResponse:
 async def notifications_page(
     request: Request,
     severity: str | None = None,
+    agent_id: str | None = None,
 ) -> HTMLResponse:
     """Render notification history and escalation log."""
-    agent = await _get_agent()
-    notifications = await get_recent_notifications(limit=100, severity=severity)
-    escalations = await get_recent_escalations(limit=50)
+    agent, agents = await _get_agent(agent_id)
+    selected_id = agent["agent_id"] if agent else None
+    notifications = await get_recent_notifications(limit=100, severity=severity, agent_id=selected_id)
+    escalations = await get_recent_escalations(agent_id=selected_id, limit=50)
 
     # Parse Claude response JSON in escalations
     for esc in escalations:
@@ -457,6 +485,8 @@ async def notifications_page(
     return templates.TemplateResponse("notifications.html", {
         "request": request,
         "agent": agent,
+        "agents": agents,
+        "selected_agent_id": agent["agent_id"] if agent else "",
         "notifications": notifications,
         "escalations": escalations,
         "severity_filter": severity or "",

--- a/brain/src/qwickguard_brain/storage.py
+++ b/brain/src/qwickguard_brain/storage.py
@@ -188,32 +188,28 @@ async def get_recent_actions(agent_id: str, limit: int = 100) -> list[dict[str, 
 
 
 async def get_recent_notifications(
-    limit: int = 50, severity: str | None = None
+    limit: int = 50,
+    severity: str | None = None,
+    agent_id: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Return recent notifications, optionally filtered by severity."""
+    """Return recent notifications, optionally filtered by severity and agent."""
+    clauses: list[str] = []
+    params: list[Any] = []
+    if severity:
+        clauses.append("severity = ?")
+        params.append(severity)
+    if agent_id:
+        clauses.append("agent_id = ?")
+        params.append(agent_id)
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+    params.append(limit)
     async with aiosqlite.connect(_db_path) as db:
         db.row_factory = aiosqlite.Row
-        if severity:
-            async with db.execute(
-                """
-                SELECT * FROM notifications
-                WHERE severity = ?
-                ORDER BY created_at DESC
-                LIMIT ?
-                """,
-                (severity, limit),
-            ) as cursor:
-                rows = await cursor.fetchall()
-        else:
-            async with db.execute(
-                """
-                SELECT * FROM notifications
-                ORDER BY created_at DESC
-                LIMIT ?
-                """,
-                (limit,),
-            ) as cursor:
-                rows = await cursor.fetchall()
+        async with db.execute(
+            f"SELECT * FROM notifications {where} ORDER BY created_at DESC LIMIT ?",
+            params,
+        ) as cursor:
+            rows = await cursor.fetchall()
     return [dict(row) for row in rows]
 
 

--- a/brain/src/qwickguard_brain/templates/audit.html
+++ b/brain/src/qwickguard_brain/templates/audit.html
@@ -10,6 +10,7 @@
   <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap;">
     <span style="font-size:13px; color:var(--text-muted); font-weight:600;">Filters:</span>
     <form id="audit-filters" method="get" action="/audit" style="display:flex; gap:10px; flex-wrap:wrap; align-items:center;">
+      {% if selected_agent_id %}<input type="hidden" name="agent_id" value="{{ selected_agent_id }}">{% endif %}
       <select name="action" onchange="this.form.submit()" style="background:var(--bg-primary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:6px 10px; font-size:13px;">
         <option value="">All Actions</option>
         {% for a in available_actions %}
@@ -23,7 +24,7 @@
         {% endfor %}
       </select>
       {% if filters.action or filters.result %}
-      <a href="/audit" class="btn btn-outline" style="font-size:12px; padding:5px 10px;">Clear</a>
+      <a href="/audit{% if selected_agent_id %}?agent_id={{ selected_agent_id }}{% endif %}" class="btn btn-outline" style="font-size:12px; padding:5px 10px;">Clear</a>
       {% endif %}
     </form>
     <span style="margin-left:auto; font-size:12px; color:var(--text-dim);">{{ actions | length }} action(s)</span>
@@ -70,7 +71,7 @@
 
   {% if has_more %}
   <div style="text-align:center; padding:16px 0;">
-    <a href="/audit?page={{ page + 1 }}{% if filters.action %}&action={{ filters.action }}{% endif %}{% if filters.result %}&result={{ filters.result }}{% endif %}"
+    <a href="/audit?page={{ page + 1 }}{% if selected_agent_id %}&agent_id={{ selected_agent_id }}{% endif %}{% if filters.action %}&action={{ filters.action }}{% endif %}{% if filters.result %}&result={{ filters.result }}{% endif %}"
        class="btn btn-outline">Load more</a>
   </div>
   {% endif %}

--- a/brain/src/qwickguard_brain/templates/base.html
+++ b/brain/src/qwickguard_brain/templates/base.html
@@ -138,12 +138,6 @@
       opacity: 0.8;
     }
 
-    .sidebar-external-link::after {
-      content: " ↗";
-      font-size: 10px;
-      opacity: 0.5;
-    }
-
     .sidebar-spacer {
       flex: 1;
     }
@@ -408,56 +402,63 @@
     </div>
   </div>
 
+  {% if agents is defined and agents | length > 1 %}
+  <div class="sidebar-section" style="padding-bottom:0;">
+    <div class="sidebar-section-label">Agent</div>
+    <div style="padding:0 8px;">
+      <select id="agent-selector"
+              onchange="switchAgent(this.value)"
+              style="width:100%; background:var(--bg-primary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:6px 8px; font-size:12.5px; cursor:pointer;">
+        {% for a in agents %}
+        <option value="{{ a.agent_id }}" {% if a.agent_id == selected_agent_id %}selected{% endif %}>
+          {{ a.hostname }}
+        </option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+  <script>
+  function switchAgent(agentId) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('agent_id', agentId);
+    window.location.href = url.toString();
+  }
+  </script>
+  {% endif %}
+
   <div class="sidebar-section">
     <div class="sidebar-section-label">Navigation</div>
+    {% set qs = '?agent_id=' ~ selected_agent_id if selected_agent_id is defined and selected_agent_id else '' %}
     <ul class="sidebar-nav">
       <li>
-        <a href="/" class="{% if active_page == 'dashboard' %}active{% endif %}">
+        <a href="/{{ qs }}" class="{% if active_page == 'dashboard' %}active{% endif %}">
           <span class="nav-icon">&#9632;</span> Dashboard
         </a>
       </li>
       <li>
-        <a href="/metrics" class="{% if active_page == 'metrics' %}active{% endif %}">
+        <a href="/metrics{{ qs }}" class="{% if active_page == 'metrics' %}active{% endif %}">
           <span class="nav-icon">&#9650;</span> Metrics
         </a>
       </li>
       <li>
-        <a href="/audit" class="{% if active_page == 'audit' %}active{% endif %}">
+        <a href="/audit{{ qs }}" class="{% if active_page == 'audit' %}active{% endif %}">
           <span class="nav-icon">&#9776;</span> Audit Log
         </a>
       </li>
       <li>
-        <a href="/runbooks" class="{% if active_page == 'runbooks' %}active{% endif %}">
-          <span class="nav-icon">&#9998;</span> Runbooks
-        </a>
-      </li>
-      <li>
-        <a href="/notifications" class="{% if active_page == 'notifications' %}active{% endif %}">
+        <a href="/notifications{{ qs }}" class="{% if active_page == 'notifications' %}active{% endif %}">
           <span class="nav-icon">&#9993;</span> Notifications
         </a>
       </li>
     </ul>
   </div>
 
-  <div class="sidebar-section mt-16">
-    <div class="sidebar-section-label">External Tools</div>
+  <div class="sidebar-section" style="border-top:1px solid var(--border); padding-top:12px;">
+    <div class="sidebar-section-label">Resources</div>
     <ul class="sidebar-nav">
       <li>
-        <a href="{{ '//' + request.headers.get('host', 'localhost').split(':')[0] + ':8090' }}"
-           target="_blank" rel="noopener" class="sidebar-external-link">
-          <span class="nav-icon">&#9760;</span> Beszel
-        </a>
-      </li>
-      <li>
-        <a href="{{ '//' + request.headers.get('host', 'localhost').split(':')[0] + ':9000' }}"
-           target="_blank" rel="noopener" class="sidebar-external-link">
-          <span class="nav-icon">&#9881;</span> Portainer
-        </a>
-      </li>
-      <li>
-        <a href="{{ '//' + request.headers.get('host', 'localhost').split(':')[0] + ':8888' }}"
-           target="_blank" rel="noopener" class="sidebar-external-link">
-          <span class="nav-icon">&#9646;</span> Dozzle
+        <a href="/runbooks{{ qs }}" class="{% if active_page == 'runbooks' %}active{% endif %}">
+          <span class="nav-icon">&#9998;</span> Runbooks
         </a>
       </li>
     </ul>

--- a/brain/src/qwickguard_brain/templates/dashboard.html
+++ b/brain/src/qwickguard_brain/templates/dashboard.html
@@ -23,7 +23,8 @@ let refreshPaused = false;
 
 async function refreshDashboard() {
   try {
-    const resp = await fetch('/dashboard/partials/overview');
+    const agentParam = '{{ selected_agent_id }}' ? '?agent_id={{ selected_agent_id }}' : '';
+    const resp = await fetch('/dashboard/partials/overview' + agentParam);
     if (resp.ok) {
       document.getElementById('dashboard-content').innerHTML = await resp.text();
     }

--- a/brain/src/qwickguard_brain/templates/metrics.html
+++ b/brain/src/qwickguard_brain/templates/metrics.html
@@ -8,7 +8,7 @@
 <div style="display:flex; align-items:center; gap:12px; margin-bottom:20px; flex-wrap:wrap;">
   <span style="font-size:13px; color:var(--text-muted);">Time Range:</span>
   {% for r in ["5m", "1h", "6h", "24h", "7d"] %}
-  <a href="/metrics?range={{ r }}"
+  <a href="/metrics?range={{ r }}{% if selected_agent_id %}&agent_id={{ selected_agent_id }}{% endif %}"
      class="btn btn-outline"
      style="{% if range == r %}border-color:var(--accent-green); color:var(--accent-green);{% endif %}">
     {{ r }}
@@ -233,7 +233,8 @@ function updateCharts(newData) {
 
 async function fetchAndUpdate() {
   try {
-    const resp = await fetch('/api/metrics/data?range=' + currentRange);
+    const agentParam = '{{ selected_agent_id }}' ? '&agent_id={{ selected_agent_id }}' : '';
+    const resp = await fetch('/api/metrics/data?range=' + currentRange + agentParam);
     if (resp.ok) {
       const newData = await resp.json();
       updateCharts(newData);

--- a/brain/src/qwickguard_brain/templates/notifications.html
+++ b/brain/src/qwickguard_brain/templates/notifications.html
@@ -36,7 +36,7 @@
     <div class="card-title" style="margin-bottom:0;">Notification History</div>
     <div style="margin-left:auto; display:flex; gap:8px;">
       {% for s in ["", "critical", "warning", "info"] %}
-      <a href="/notifications{% if s %}?severity={{ s }}{% endif %}"
+      <a href="/notifications{% if s or selected_agent_id %}?{% endif %}{% if s %}severity={{ s }}{% endif %}{% if s and selected_agent_id %}&{% endif %}{% if selected_agent_id %}agent_id={{ selected_agent_id }}{% endif %}"
          class="btn btn-outline" style="font-size:11px; padding:4px 10px;
          {% if severity_filter == s %}border-color:var(--accent-green); color:var(--accent-green);{% endif %}">
         {% if s %}{{ s }}{% else %}All{% endif %}

--- a/brain/src/qwickguard_brain/templates/partials/system_status.html
+++ b/brain/src/qwickguard_brain/templates/partials/system_status.html
@@ -256,23 +256,4 @@
   {% endif %}
 </div>
 
-<!-- Row 5: Quick links -->
-<div class="mt-16" style="display:flex; gap:12px; flex-wrap:wrap;">
-  <a class="btn btn-outline"
-     href="{{ '//' + request.headers.get('host', 'localhost').split(':')[0] + ':8090' }}"
-     target="_blank" rel="noopener">
-    &#9760; Beszel
-  </a>
-  <a class="btn btn-outline"
-     href="{{ '//' + request.headers.get('host', 'localhost').split(':')[0] + ':9000' }}"
-     target="_blank" rel="noopener">
-    &#9881; Portainer
-  </a>
-  <a class="btn btn-outline"
-     href="{{ '//' + request.headers.get('host', 'localhost').split(':')[0] + ':8888' }}"
-     target="_blank" rel="noopener">
-    &#9646; Dozzle
-  </a>
-</div>
-
 {% endif %}

--- a/brain/src/qwickguard_brain/templates/runbook_detail.html
+++ b/brain/src/qwickguard_brain/templates/runbook_detail.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div style="margin-bottom:16px;">
-  <a href="/runbooks" class="btn btn-outline" style="font-size:12px;">&#8592; Back to Runbooks</a>
+  <a href="/runbooks{% if selected_agent_id %}?agent_id={{ selected_agent_id }}{% endif %}" class="btn btn-outline" style="font-size:12px;">&#8592; Back to Runbooks</a>
 </div>
 
 <div class="card">

--- a/brain/src/qwickguard_brain/templates/runbooks.html
+++ b/brain/src/qwickguard_brain/templates/runbooks.html
@@ -8,7 +8,7 @@
 {% if runbooks %}
 <div class="grid-2">
   {% for rb in runbooks %}
-  <a href="/runbooks/{{ rb.filename }}" class="card" style="text-decoration:none; transition:border-color 0.15s;">
+  <a href="/runbooks/{{ rb.filename }}{% if selected_agent_id %}?agent_id={{ selected_agent_id }}{% endif %}" class="card" style="text-decoration:none; transition:border-color 0.15s;">
     <div class="card-title" style="margin-bottom:8px;">{{ rb.title }}</div>
     {% if rb.severity %}
     <span class="badge {% if rb.severity == 'critical' %}badge-red{% elif rb.severity == 'warning' %}badge-orange{% else %}badge-gray{% endif %}" style="margin-bottom:8px;">

--- a/configs/oci-gateway.yaml
+++ b/configs/oci-gateway.yaml
@@ -1,0 +1,31 @@
+# QwickGuard Server Configuration
+# oci-gateway - Oracle Cloud gateway/routing server (Ubuntu 22.04 ARM, 1 OCPU, 2GB RAM)
+hostname: oci-gateway
+agent_id: oci-gateway-1
+brain_url: http://100.100.236.12:8500  # macmini-devserver via Tailscale
+compute_worker_url: http://localhost:8001
+
+check_interval_seconds: 300  # 5 minutes
+
+thresholds:
+  cpu_warning: 80
+  cpu_critical: 95
+  ram_warning: 85
+  ram_critical: 95
+  disk_warning: 80
+  disk_critical: 90
+
+# Note: CapRover uses Docker Swarm; container names include dynamic suffixes.
+# Container monitoring skipped for now.
+containers: []
+
+services:
+  - name: guardian
+    url: http://localhost:80/
+    critical: true
+
+backups: []
+
+github_runners: []
+
+zombie_patterns: []

--- a/configs/oci-main.yaml
+++ b/configs/oci-main.yaml
@@ -1,0 +1,32 @@
+# QwickGuard Server Configuration
+# oci-main - Oracle Cloud primary app server (Ubuntu 22.04 ARM, 2 OCPU, 18GB RAM)
+hostname: oci-main
+agent_id: oci-main-1
+brain_url: http://100.100.236.12:8500  # macmini-devserver via Tailscale
+compute_worker_url: http://localhost:8001
+
+check_interval_seconds: 300  # 5 minutes
+
+thresholds:
+  cpu_warning: 80
+  cpu_critical: 95
+  ram_warning: 85
+  ram_critical: 95
+  disk_warning: 80
+  disk_critical: 90
+
+# Note: CapRover uses Docker Swarm; container names include dynamic suffixes
+# (e.g. srv-captain--faabzi.1.<hash>). Container monitoring skipped for now.
+# TODO: Add prefix-matching support to the Docker collector for Swarm services.
+containers: []
+
+services:
+  - name: faabzi
+    url: http://localhost:80/
+    critical: true
+
+backups: []
+
+github_runners: []
+
+zombie_patterns: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # QwickGuard Monitoring Stack
-# Deploy on macmini: docker compose up -d
+# Deploy on macmini (Docker): docker compose up -d
+# Deploy on macmini (Podman): DOCKER_SOCKET=/run/user/501/podman/podman.sock podman compose up -d
 # UIs accessible via Tailscale at http://macmini-devserver:<port>
 
 services:
@@ -9,7 +10,7 @@ services:
     restart: unless-stopped
     privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
     environment:
       CONTAINERS: 1
       SERVICES: 1
@@ -84,7 +85,7 @@ services:
     network_mode: host
     volumes:
       - beszel_socket:/beszel_socket
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
     environment:
       LISTEN: /beszel_socket/beszel.sock
       KEY: "${BESZEL_AGENT_KEY}"


### PR DESCRIPTION
Adapt docker-compose.yml to work with both Docker and Podman socket paths.

Changes:
- socket-proxy and beszel-agent now use ${DOCKER_SOCKET:-/var/run/docker.sock}
- .env.example documents DOCKER_SOCKET with Podman value
- README updated with Podman socket activation prerequisites and deploy command

Closes #52